### PR TITLE
fix: fix the issue of not updating last_update when obtaining the leader

### DIFF
--- a/leader/mysql.go
+++ b/leader/mysql.go
@@ -144,11 +144,11 @@ const electionSQL = `
 INSERT INTO leader_election (leader_name, node_name, last_update) VALUES (?, ?, ?)
 ON DUPLICATE KEY UPDATE
 node_name = IF(last_update < DATE_SUB(VALUES(last_update), INTERVAL ? SECOND), VALUES(node_name), node_name),
-last_update = IF(node_name = VALUES(node_name), VALUES(last_update), last_update)
+last_update = IF(node_name = VALUES(node_name) OR last_update < DATE_SUB(VALUES(last_update), INTERVAL ? SECOND), VALUES(last_update), last_update)
 `
 
 func (m *mysqlLeader) election(ctx context.Context) error {
-	_, err := m.db.ExecContext(ctx, electionSQL, m.leaderName, m.nodeName, m.clock.Now(), int64(m.age.Seconds()))
+	_, err := m.db.ExecContext(ctx, electionSQL, m.leaderName, m.nodeName, m.clock.Now(), int64(m.age.Seconds()), int64(m.age.Seconds()))
 	if err != nil {
 		err = m.onError(err)
 	}


### PR DESCRIPTION
There is an obvious issue with this statement `INSERT INTO leader_election ...` . After updating the node_name, the last_update field was not updated at the same time (it will not be updated until the next leader refresh), which may cause other nodes to obtain the leader before the next leader refresh.

The correct approach should be to update both the node_name and the last_update at the same time

